### PR TITLE
READMEにDB設計を記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,53 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## messagesテーブル
+
+| Column | Type | Options |
+|--------|------|---------|
+| body | text |
+| image | string |
+| user_id | integer | null: false, foregin_key: true |
+| group_id | integer | null: false, foregin_key: true |
+
+### Association
+
+belong_to :group
+belong_to :user
+
+## usersテーブル
+
+| Column | Type | Options |
+|--------|------|---------|
+| name | string | null: false, add_index: true |
+| email | string | null: false, unique: true |
+
+### Association
+
+has_many :groups_users
+has_many :groups, through: groups_users
+has_many :messages
+
+##groupsテーブル
+| Column | Type | Options |
+|--------|------|---------|
+|group_name | string | null: false, unique: true |
+
+### Association
+
+has_many :groups_users
+has_many :users, through: groups_users
+has_many :messages
+
+##groups_usersテーブル
+
+| Column | Type | Options |
+|--------|------|---------|
+| user_id | integer | null: false, foregin_key: true |
+| group_id | integer | null: false, foregin_key: true |
+
+### Association
+
+belongs_to :group
+belongs_to :user

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ has_many :groups_users
 has_many :groups, through: groups_users
 has_many :messages
 
-##groupsテーブル
+## groupsテーブル
+
 | Column | Type | Options |
 |--------|------|---------|
-|group_name | string | null: false, unique: true |
+| group_name | string | null: false, unique: true |
 
 ### Association
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Things you may want to cover:
 
 * has_many :groups_users
 * has_many :users, through: groups_users
-* has_many :messages*
+* has_many :messages
 
 ##groups_usersテーブル
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Things you may want to cover:
 
 ### Association
 
-belong_to :group
-belong_to :user
+* belong_to :group
+* belong_to :user
 
 ## usersテーブル
 
@@ -46,9 +46,9 @@ belong_to :user
 
 ### Association
 
-has_many :groups_users
-has_many :groups, through: groups_users
-has_many :messages
+* has_many :groups_users
+* has_many :groups, through: groups_users
+* has_many :messages
 
 ## groupsテーブル
 
@@ -58,9 +58,9 @@ has_many :messages
 
 ### Association
 
-has_many :groups_users
-has_many :users, through: groups_users
-has_many :messages
+* has_many :groups_users
+* has_many :users, through: groups_users
+* has_many :messages*
 
 ##groups_usersテーブル
 
@@ -71,5 +71,5 @@ has_many :messages
 
 ### Association
 
-belongs_to :group
-belongs_to :user
+* belongs_to :group
+* belongs_to :user

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Things you may want to cover:
 
 | Column | Type | Options |
 |--------|------|---------|
-| group_name | string | null: false, unique: true |
+| name | string | null: false, unique: true |
 
 ### Association
 


### PR DESCRIPTION
# What
READMEにDB設計を記載を行った。messagesテーブル、usersテーブル、groupsテーブル、groups_usersテーブルにカラム名、カラムの型、カラムのオプション、アソシエーションを記載した。

# Why
DB設計の方法を覚える為。